### PR TITLE
Modifies relative URLs for model paths

### DIFF
--- a/src/networks.py
+++ b/src/networks.py
@@ -62,13 +62,13 @@ def get_network(type, placeholder_input, sess_for_load=None, trainable=True):
 
 def get_graph_path(model_name):
     return {
-        'cmu_640x480': './models/graph/cmu_640x480/graph_opt.pb',
-        'cmuq_640x480': './models/graph/cmu_640x480/graph_q.pb',
+        'cmu_640x480': '../models/graph/cmu_640x480/graph_opt.pb',
+        'cmuq_640x480': '../models/graph/cmu_640x480/graph_q.pb',
 
-        'cmu_640x360': './models/graph/cmu_640x360/graph_opt.pb',
-        'cmuq_640x360': './models/graph/cmu_640x360/graph_q.pb',
+        'cmu_640x360': '../models/graph/cmu_640x360/graph_opt.pb',
+        'cmuq_640x360': '../models/graph/cmu_640x360/graph_q.pb',
 
-        'mobilenet_thin_432x368': './models/graph/mobilenet_thin_432x368/graph_opt.pb',
+        'mobilenet_thin_432x368': '../models/graph/mobilenet_thin_432x368/graph_opt.pb',
     }[model_name]
 
 


### PR DESCRIPTION
- TF couldn't find models on first launch for image inferencing. Missed in the file re-organization.