### PR TITLE
cv2.line function return NoneType object.

### DIFF
--- a/src/estimator.py
+++ b/src/estimator.py
@@ -309,7 +309,8 @@ class TfPoseEstimator:
                 if pair[0] not in human.body_parts.keys() or pair[1] not in human.body_parts.keys():
                     continue
 
-                npimg = cv2.line(npimg, centers[pair[0]], centers[pair[1]], common.CocoColors[pair_order], 3)
+                #npimg = cv2.line(npimg, centers[pair[0]], centers[pair[1]], common.CocoColors[pair_order], 3)
+                cv2.line(npimg, centers[pair[0]], centers[pair[1]], common.CocoColors[pair_order], 3)
 
         return npimg
 


### PR DESCRIPTION
src/run.py did not work because TfPoseEstimator.draw_humans return NonType object.
investigateing the cause and found that in the line 312 of estimator.py,  the return value of cv2.line was assigned to npimg.