### PR TITLE
Fixed issues causing catkin build to fail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
+# setup.py is called during catkin build
+catkin_python_setup()
+
 # Generate messages in the 'msg' folder
 add_message_files(
   FILES

--- a/scripts/broadcaster_ros.py
+++ b/scripts/broadcaster_ros.py
@@ -12,8 +12,8 @@ from std_msgs.msg import String
 from sensor_msgs.msg import Image
 from tfpose_ros.msg import Persons, Person, BodyPartElm
 
-from estimator import TfPoseEstimator
-from networks import model_wh, get_graph_path
+from tf_pose.estimator import TfPoseEstimator
+from tf_pose.networks import model_wh, get_graph_path
 
 
 def humans_to_msg(humans):

--- a/scripts/visualization.py
+++ b/scripts/visualization.py
@@ -6,7 +6,7 @@ from sensor_msgs.msg import Image
 from cv_bridge import CvBridge, CvBridgeError
 
 from tfpose_ros.msg import Persons, Person, BodyPartElm
-from estimator import Human, BodyPart, TfPoseEstimator
+from tf_pose.estimator import Human, BodyPart, TfPoseEstimator
 
 
 class VideoFrames:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from distutils.core import setup, Extension
 
 import numpy as np
 
-_VERSION = '0.1'
+_VERSION = '0.1.0'
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 subprocess.check_output(["bash", "models/graph/cmu/download.sh"], cwd=cwd)


### PR DESCRIPTION
When using catkin build to deploy the project, the build process failed for multiple reasons.
Each commit fixed a different one. 

After merging these commits, it is possible (again?) to just clone the project into your catkin workspace, build and run the nodes without any errors.  

Tip: 
For those installing with catkin build, add the --verbose flag to see the progress of the weight downloads.