### PR TITLE
remove obsolete "use_calibration" option

### DIFF
--- a/tf_pose/estimator.py
+++ b/tf_pose/estimator.py
@@ -324,7 +324,6 @@ class TfPoseEstimator:
                 minimum_segment_size=3,
                 is_dynamic_op=True,
                 maximum_cached_engines=int(1e3),
-                use_calibration=True,
             )
 
         self.graph = tf.get_default_graph()


### PR DESCRIPTION
https://github.com/ildoonet/tf-pose-estimation/issues/497#issuecomment-521896352

As mentioned in the above issue, tensorflow.contrib.tensorrt.create_inference_graph() seems to no longer support 'use_calibration' argument.
tensorflow/tensorflow@2590dc3#diff-c9068b7e53b77bdcfe37dff6a4be8b58

In the older version (e.g. Tensorflow 1.13.1), the default of use_calibration was True. So, there is no need to specify use_calibration=True.

I think simply removing the 'use_calibration=True' argument is a reasonable solution.
